### PR TITLE
Support BuildId and DefinitionName variables for URI

### DIFF
--- a/AllureConfig/index.html
+++ b/AllureConfig/index.html
@@ -51,7 +51,7 @@
     <div class="ms-TextField">
         <label class="ms-Label" for="baseUrl">Base url</label>
         <input class="ms-TextField-field" id="baseUrl" name="baseUrl" type="url">
-        <span class="ms-TextField-description">Base url where you host your Allure reports, use varible $(Build.BuildNumber) for replace it on corresponding build number</span>
+        <span class="ms-TextField-description">Base url where you host your Allure reports, use varibles $(Build.BuildNumber), $(Build.BuildId) and $(Build.DefinitionName) for replace it on corresponding build number</span>
     </div>
     <button class="ms-Button ms-Button--primary">
         <span class="ms-Button-label">Save</span>

--- a/AllureReportTab/index.html
+++ b/AllureReportTab/index.html
@@ -15,7 +15,7 @@
                     console.log(build);
                     VSS.getService(VSS.ServiceIds.ExtensionData).then(function(dataService) {
                         dataService.getValue('baseUrl', {scopeType: 'Default'}).then(function(baseUrl) {
-                            showReport(baseUrl, build.buildNumber);
+                            showReport(baseUrl, build.buildNumber, build.id, build.definition.name);
                             VSS.notifyLoadSucceeded();
                         });
                     });
@@ -23,8 +23,10 @@
             }
         });
 
-        function showReport(baseUrl, buildNumber) {
+        function showReport(baseUrl, buildNumber, buildId, definitionName) {
             var reportUrl = baseUrl.replace(/\$\(Build\.BuildNumber\)/ig, buildNumber);
+            reportUrl = reportUrl.replace(/\$\(Build\.BuildId\)/ig, buildId);
+            reportUrl = reportUrl.replace(/\$\(Build\.DefinitionName\)/ig, encodeURIComponent(definitionName));
             var iframe = document.getElementById('allure-report-iframe');
             iframe.src = reportUrl;
         }


### PR DESCRIPTION
When there are several pipelines with simular build naming rule defined, it is possible that two builds in different pipelines will have same BuildNumber.
To resolve this issue we need to support more variables in Base URL template.